### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,6 +25,7 @@ class ItemsController < ApplicationController
 
   def edit
     return unless @item.user != current_user
+
     redirect_to root_path
   end
 
@@ -53,6 +54,6 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:image, :item_name, :item_description, :category_id, :item_condition_id, :item_postage_id,
-                                  :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
+                                 :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+
   def index
     @item = Item.order(created_at: :desc)
   end
@@ -32,6 +33,15 @@ class ItemsController < ApplicationController
       redirect_to item_path, notice: '変更が完了しました。'
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if @item.user == current_user
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user == @item.user %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
         <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
   post '/items/new', to: 'items#create'
 end


### PR DESCRIPTION
# What
- destroyアクションのルーティングを設定する
- 削除ボタンを実装する
- destroyアクションを定義する
# Why
商品削除機能実装のため
# Gyazo
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/8621ce0f6c80345af97d1340cdf62d8b